### PR TITLE
DQSHFE-6 Fixed Placeholder Issue

### DIFF
--- a/core/src/main/java/com/shell/core/models/Cards.java
+++ b/core/src/main/java/com/shell/core/models/Cards.java
@@ -7,8 +7,17 @@ import java.util.List;
  * Represents a container that holds multiple card items.
  */
 public interface Cards {
+
     /**
      * @return list of card items.
      */
     List<CardsItems> getCards();
+
+    /**
+     * Checks if the component is empty (i.e., no cards are configured).
+     *
+     * @return true if the component has no cards, false otherwise.
+     */
+    public boolean isEmpty();
+
 }

--- a/core/src/main/java/com/shell/core/models/CardsItems.java
+++ b/core/src/main/java/com/shell/core/models/CardsItems.java
@@ -5,6 +5,7 @@ package com.shell.core.models;
  * Represents individual card properties like image, title, description, and button visibility.
  */
 public interface CardsItems {
+
     /**
      * @return image path for the card
      */

--- a/core/src/main/java/com/shell/core/models/impl/CardsImpl.java
+++ b/core/src/main/java/com/shell/core/models/impl/CardsImpl.java
@@ -40,4 +40,18 @@ public class CardsImpl implements Cards {
         LOG.info("Fetching card list. Total cards: {}", cards != null ? cards.size() : 0);
         return cards;
     }
+    /**
+     * Checks whether the card component is empty.
+     * This method returns {@code true} if the list of cards is either {@code null} or contains no elements.
+     * Useful for determining whether to render the component or display a placeholder in the authoring interface.
+     *
+     * @return {@code true} if there are no cards to display; {@code false} otherwise.
+     */
+    @Override
+    public boolean isEmpty() {
+        boolean isEmpty = cards == null || cards.isEmpty();
+        LOG.info("Checking if the component is empty: {}", isEmpty);
+        return isEmpty;
+    }
+
 }

--- a/ui.apps/src/main/content/jcr_root/apps/shell/components/content/cards/cards.html
+++ b/ui.apps/src/main/content/jcr_root/apps/shell/components/content/cards/cards.html
@@ -1,6 +1,7 @@
-<sly data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html"/>
-<sly data-sly-use.model="com.shell.core.models.Cards"/>
-<section class="shell-card-section">
+<sly data-sly-use.model="com.shell.core.models.Cards" />
+<sly data-sly-use.placeholderTemplate="core/wcm/components/commons/v1/templates.html" />
+
+<section class="shell-card-section" data-sly-test="${!model.empty}">
     <sly data-sly-list.card="${model.cards}">
         <div class="shell-card ${style.cssClass}">
             <img src="${card.fileReference}" alt="${card.title}" class="card-image"/>
@@ -8,8 +9,9 @@
                 <h3 data-sly-test="${card.title}" class="card-title">${card.title @ context='html'}</h3>
                 <p data-sly-test="${card.description}" class="card-description">${card.description @ context='html'}</p>
             </div>
-           <sly data-sly-resource="${'btn' @ resourceType='core/wcm/components/button/v1/button'}"></sly>
-            </sly>
         </div>
     </sly>
 </section>
+
+<!-- Corrected Placeholder support -->
+<sly data-sly-call="${placeholderTemplate.placeholder @ isEmpty=model.empty}" />


### PR DESCRIPTION
**Description**
The Shell Cards component was not displaying the placeholder name (e.g., "Shell Cards") when added to a page in author mode. Instead, it showed a generic "Drag components here" or remained invisible when the component was empty. This created confusion for authors during page authoring.

**Files Modified**
1.core/src/main/java/com/shell/core/models/Cards.java
2.core/src/main/java/com/shell/core/models/CardsItems.java
3.core/src/main/java/com/shell/core/models/impl/CardsImpl.java
4.ui.apps/src/main/content/jcr_root/apps/shell/components/content/cards/cards.html

## Changes Introduced

- [ ] Feature added  
- [x] Bug fix  
- [ ] Refactor  
- [ ] Documentation update  

## ✅ Checklist

- [x] I have tested the changes locally  
- [ ] I have followed the coding style of the project  
- [ ] I have updated relevant documentation if needed  

---
**Peer Review**
@dq-aem-chandrika 

**Lead Review**
- @dq-aem-arun
- @dq-aem-nirbhai
- @dq-aem-sibaram

