### PR TITLE
DQSHFE-37 shell templates implementation and synching

### DIFF
--- a/ui.content/src/main/content/jcr_root/conf/shell/settings/wcm/templates/shell-contentpage/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/shell/settings/wcm/templates/shell-contentpage/.content.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Template">
+    <jcr:content
+        cq:lastModified="{Date}2025-05-23T13:02:05.500+05:30"
+        cq:lastModifiedBy="admin"
+        cq:templateType="/conf/shell/settings/wcm/template-types/page"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="Shell-ContentPage"
+        status="enabled"/>
+</jcr:root>

--- a/ui.content/src/main/content/jcr_root/conf/shell/settings/wcm/templates/shell-contentpage/initial/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/shell/settings/wcm/templates/shell-contentpage/initial/.content.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:template="/conf/shell/settings/wcm/templates/shell-contentpage"
+        jcr:primaryType="cq:PageContent"
+        sling:resourceType="shell/components/page">
+        <root
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="shell/components/container"
+            layout="responsiveGrid">
+            <container
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="shell/components/container"
+                layout="responsiveGrid"/>
+        </root>
+    </jcr:content>
+</jcr:root>

--- a/ui.content/src/main/content/jcr_root/conf/shell/settings/wcm/templates/shell-contentpage/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/shell/settings/wcm/templates/shell-contentpage/policies/.content.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:policy="shell/components/page/policy"
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="wcm/core/components/policies/mappings">
+        <root
+            cq:policy="shell/components/container/policy_1574694950110"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="wcm/core/components/policies/mapping">
+            <container
+                cq:policy="shell/components/container/policy_1574695586800"
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="wcm/core/components/policies/mapping"/>
+        </root>
+    </jcr:content>
+</jcr:root>

--- a/ui.content/src/main/content/jcr_root/conf/shell/settings/wcm/templates/shell-contentpage/structure/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/shell/settings/wcm/templates/shell-contentpage/structure/.content.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:deviceGroups="[mobile/groups/responsive]"
+        cq:lastModified="{Date}2025-05-23T13:02:05.500+05:30"
+        cq:lastModifiedBy="admin"
+        cq:template="/conf/shell/settings/wcm/templates/shell-contentpage"
+        jcr:primaryType="cq:PageContent"
+        sling:resourceType="shell/components/page">
+        <root
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="shell/components/container"
+            layout="responsiveGrid">
+            <experiencefragment-header
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="shell/components/experiencefragment"
+                fragmentVariationPath="/content/experience-fragments/shell/language-masters/en/site/header/master"/>
+            <container
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="shell/components/container"
+                editable="{Boolean}true"
+                layout="responsiveGrid"/>
+            <experiencefragment
+                jcr:created="{Date}2025-05-23T13:01:39.643+05:30"
+                jcr:createdBy="admin"
+                jcr:lastModified="{Date}2025-05-23T13:02:05.495+05:30"
+                jcr:lastModifiedBy="admin"
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="shell/components/experiencefragment"
+                fragmentVariationPath="/content/experience-fragments/shell/us/en/site/footer/master"/>
+        </root>
+        <cq:responsive jcr:primaryType="nt:unstructured">
+            <breakpoints jcr:primaryType="nt:unstructured">
+                <phone
+                    jcr:primaryType="nt:unstructured"
+                    title="Smaller Screen"
+                    width="{Long}768"/>
+                <tablet
+                    jcr:primaryType="nt:unstructured"
+                    title="Tablet"
+                    width="{Long}1200"/>
+            </breakpoints>
+        </cq:responsive>
+    </jcr:content>
+</jcr:root>

--- a/ui.content/src/main/content/jcr_root/conf/shell/settings/wcm/templates/shell-homepage/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/shell/settings/wcm/templates/shell-homepage/.content.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Template">
+    <jcr:content
+        cq:lastModified="{Date}2025-05-23T13:03:03.557+05:30"
+        cq:lastModifiedBy="admin"
+        cq:templateType="/conf/shell/settings/wcm/template-types/page"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="Shell-HomePage"
+        status="enabled"/>
+</jcr:root>

--- a/ui.content/src/main/content/jcr_root/conf/shell/settings/wcm/templates/shell-homepage/initial/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/shell/settings/wcm/templates/shell-homepage/initial/.content.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:template="/conf/shell/settings/wcm/templates/shell-homepage"
+        jcr:primaryType="cq:PageContent"
+        sling:resourceType="shell/components/page">
+        <root
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="shell/components/container"
+            layout="responsiveGrid">
+            <container
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="shell/components/container"
+                layout="responsiveGrid"/>
+        </root>
+    </jcr:content>
+</jcr:root>

--- a/ui.content/src/main/content/jcr_root/conf/shell/settings/wcm/templates/shell-homepage/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/shell/settings/wcm/templates/shell-homepage/policies/.content.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:policy="shell/components/page/policy"
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="wcm/core/components/policies/mappings">
+        <root
+            cq:policy="shell/components/container/policy_1574694950110"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="wcm/core/components/policies/mapping">
+            <container
+                cq:policy="shell/components/container/policy_1574695586800"
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="wcm/core/components/policies/mapping"/>
+        </root>
+    </jcr:content>
+</jcr:root>

--- a/ui.content/src/main/content/jcr_root/conf/shell/settings/wcm/templates/shell-homepage/structure/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/shell/settings/wcm/templates/shell-homepage/structure/.content.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:deviceGroups="[mobile/groups/responsive]"
+        cq:lastModified="{Date}2025-05-23T13:03:03.557+05:30"
+        cq:lastModifiedBy="admin"
+        cq:template="/conf/shell/settings/wcm/templates/shell-homepage"
+        jcr:primaryType="cq:PageContent"
+        sling:resourceType="shell/components/page">
+        <root
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="shell/components/container"
+            layout="responsiveGrid">
+            <experiencefragment-header
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="shell/components/experiencefragment"
+                fragmentVariationPath="/content/experience-fragments/shell/language-masters/en/site/header/master"/>
+            <container_1465230413
+                jcr:created="{Date}2025-05-23T13:02:40.166+05:30"
+                jcr:createdBy="admin"
+                jcr:lastModified="{Date}2025-05-23T13:02:40.166+05:30"
+                jcr:lastModifiedBy="admin"
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="shell/components/container"/>
+            <container
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="shell/components/container"
+                editable="{Boolean}true"
+                layout="responsiveGrid"/>
+            <experiencefragment
+                jcr:created="{Date}2025-05-23T13:02:48.180+05:30"
+                jcr:createdBy="admin"
+                jcr:lastModified="{Date}2025-05-23T13:03:03.553+05:30"
+                jcr:lastModifiedBy="admin"
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="shell/components/experiencefragment"
+                fragmentVariationPath="/content/experience-fragments/shell/us/en/site/footer/master"/>
+        </root>
+        <cq:responsive jcr:primaryType="nt:unstructured">
+            <breakpoints jcr:primaryType="nt:unstructured">
+                <phone
+                    jcr:primaryType="nt:unstructured"
+                    title="Smaller Screen"
+                    width="{Long}768"/>
+                <tablet
+                    jcr:primaryType="nt:unstructured"
+                    title="Tablet"
+                    width="{Long}1200"/>
+            </breakpoints>
+        </cq:responsive>
+    </jcr:content>
+</jcr:root>


### PR DESCRIPTION
This PR is about Template creation 
I have created two editable templates (one for the homepage and one for standard content pages)
So that authors can easily create consistent pages with a shared header and footer using Experience Fragments.

Files Added
1. /conf/shell/settings/wcm/templates/shell-homepage
2. /conf/shell/settings/wcm/templates/shell-contentpage


## Changes Introduced

- [x] Feature added  
- [ ] Bug fix  
- [ ] Refactor  
- [ ] Documentation update  

## ✅ Checklist

- [x] I have tested the changes locally  
- [x] I have followed the coding style of the project  
- [ ] I have updated relevant documentation if needed  

### **Peer Review**
@dq-aem-anilkumar 

### **Lead Review**
@dq-aem-nirbhai 
@dq-aem-arun 
@dq-aem-sibaram 
